### PR TITLE
Replace pip with pipx for CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Advantages over copying and pasting from ChatGPT:
 
 ## 🚀 Quick Start
 
-    pip install clipea-cli
+    pipx install clipea-cli
     clipea setup
     clipea alias
 
@@ -177,7 +177,7 @@ Or development mode:
 
 ### With PyPi
 
-    pip install clipea-cli
+    pipx install clipea-cli
 
 ### Zsh Shell integration and Alias
 


### PR DESCRIPTION
Python as a community is demoting global contexts, historically the default, to favor local ones, which include virtual environments. A global pip install will fail by default for Python >=3.11 in Debian-based distros, as well as other [externally managed environments](https://peps.python.org/pep-0668/):

```bash
$ pip install clipea-cli
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

A popular way to install user-wide binaries (as opposed to a package which is part of a project) is by using [pipx](https://pypa.github.io/pipx/) instead. When part of a development installation, `pip install` is probably still a good choice.
