### PR TITLE
Bash history and edits

### DIFF
--- a/clipea/__init__.py
+++ b/clipea/__init__.py
@@ -5,6 +5,11 @@
 import os
 import sys
 from clipea import utils, cli
+from loguru import logger as log
+
+# set default log level to INFO
+log.remove()
+log.add(sys.stderr, level="INFO")
 
 
 CLIPEA_DIR: str = os.path.dirname(os.path.realpath(__file__))
@@ -18,4 +23,5 @@ ENV: dict[str, str] = {
     "platform": sys.platform,
     "editor": os.getenv("EDITOR", "nano"),
 }
+log.trace(f"ENV: {ENV}")
 SYSTEM_PROMPT: str = utils.read_file(SYSTEM_PROMPT_FILE) + str(ENV)

--- a/clipea/__init__.py
+++ b/clipea/__init__.py
@@ -1,6 +1,7 @@
 """Clipea application
 📎🟢 Like Clippy but for the CLI. A blazing fast AI helper for your command line
 """
+
 import os
 import sys
 from clipea import utils, cli
@@ -13,7 +14,7 @@ SYSTEM_PROMPT_FILE: str = utils.get_config_file_with_fallback(
     home=HOME_PATH, fallback=CLIPEA_DIR, appname="clipea", filename="system-prompt.txt"
 )
 ENV: dict[str, str] = {
-    "shell": cli.get_shell(),
+    "shell": cli.get_current_shell(),
     "platform": sys.platform,
     "editor": os.getenv("EDITOR", "nano"),
 }

--- a/clipea/__main__.py
+++ b/clipea/__main__.py
@@ -1,5 +1,6 @@
 """Clipea application entry point
 """
+
 import sys
 import shutil
 from clipea import router

--- a/clipea/__main__.py
+++ b/clipea/__main__.py
@@ -12,6 +12,7 @@ def clipea_main() -> None:
     and then prompts the user for input. It then routes the user's input
     to the appropriate command in the router.
     """
+
     if shutil.which("llm") is None:
         sys.exit('Error: dependency "llm" not found. Run "clipea setup" to install')
 

--- a/clipea/cli.py
+++ b/clipea/cli.py
@@ -32,8 +32,8 @@ def get_current_shell() -> str:
     Returns:
         str: shell's name
     """
-    FALLBACK_SHELL_PATH = "/bin/sh"  # last resort
-    AVAILABLE_SHELLS = [
+    fallback_shell_path = "/bin/sh"  # last resort
+    available_shells = [
         "bash",
         "sh",
         "zsh",
@@ -44,8 +44,8 @@ def get_current_shell() -> str:
     # If clipea is invoked from a shell script, the `ps` command will return
     # the script that invoked it, not the shell that is running. In this case,
     # we fallback to the preferred user shell, indicated by the env var $SHELL:
-    if current_shell not in AVAILABLE_SHELLS:
-        current_shell = os.path.basename(os.environ.get("SHELL", FALLBACK_SHELL_PATH))
+    if current_shell not in available_shells:
+        current_shell = os.path.basename(os.environ.get("SHELL", fallback_shell_path))
     print(f"Current shell: {current_shell}")
     return current_shell
 

--- a/clipea/cli.py
+++ b/clipea/cli.py
@@ -1,10 +1,13 @@
 """CLI
 Interactions with the terminal
 """
+
+import readline
 import os
 import sys
 import subprocess
 import shutil
+from typing import Optional
 
 
 def get_input(max_len: int = 1 << 13) -> str:
@@ -18,31 +21,104 @@ def get_input(max_len: int = 1 << 13) -> str:
         data = input()
     if len(data) > max_len:
         raise ValueError(
-            f"Error: Input too long! Maximum {max_len} characters allowed.\
-                 Try limiting your input using 'head -c {max_len} file.txt"
+            f"Error: Input too long! Maximum {max_len} characters allowed.             "
+            f"    Try limiting your input using 'head -c {max_len} file.txt"
         )
     return data
 
 
-def get_shell() -> str:
-    """Get user's default shell
-
+def get_current_shell() -> str:
+    """Attempts to gets the current shell running
     Returns:
         str: shell's name
     """
-
-    return (
+    FALLBACK_SHELL_PATH = "/bin/sh"  # last resort
+    AVAILABLE_SHELLS = [
+        "bash",
+        "sh",
+        "zsh",
+    ]
+    current_shell = (
         os.popen("ps -o comm= -p $(ps -o ppid= -p $(ps -o ppid= -p $$))").read().strip()
     )
+    # If clipea is invoked from a shell script, the `ps` command will return
+    # the script that invoked it, not the shell that is running. In this case,
+    # we fallback to the preferred user shell, indicated by the env var $SHELL:
+    if current_shell not in AVAILABLE_SHELLS:
+        current_shell = os.path.basename(os.environ.get("SHELL", FALLBACK_SHELL_PATH))
+    print(f"Current shell: {current_shell}")
+    return current_shell
 
 
-def execute_with_prompt(cmd: str, shell: str = None) -> None:
-    """Asks the user if he wants to execute a command, executes it if so
+def get_history_cmd(cmd: str) -> str:
+    """Adds a command to the shell's history
+    Args:
+        cmd (str): command to add
+    """
+    shell = get_current_shell()
+    if shell == "zsh":
+        return " ".join(["print", "-s", cmd])
+    elif shell == "bash":
+        return " ".join(["history", "-a", cmd])
 
+
+def find_shell(shell_name: str) -> str | None:
+    """Finds the path to the shell passed
+    Args:
+        shell_name: shell's name
+    Returns:
+        path to the shell, or None if not found
+    """
+    if shutil.which(shell_name) is None:
+        raise ValueError(f"Error: {shell_name} not found in PATH")
+    return shutil.which(shell_name)
+
+
+def edit_cmd(innacurate_cmd: str) -> str:
+    """Lets the user modify a command and returns it."""
+    # Set the default text as the pre-fill for readline
+    readline.set_startup_hook(lambda: readline.insert_text(innacurate_cmd))
+
+    try:
+        # The user can now edit the command and press Enter to submit
+        user_approved_cmd = input("Edit, then press ENTER to run:\t")
+    finally:
+        # Make sure to reset the startup hook so that future uses of
+        # raw_input won't have the text inserted.
+        readline.set_startup_hook()
+
+    return user_approved_cmd
+
+
+def execute_after_approval(dirty_cmd: str, shell: Optional[str] = None) -> str | None:
+    """Ask user confirmation for running a command or editing it.
+
+    If not an interactive shell (e.g. sourced script), the function does nothing.
     Args:
         cmd (str): command to execute
         shell (str, optional): to execute with a particuliar shell. Defaults to None.
+    Returns:
+        the command executed (or None) to be added to the history
     """
-    answer = input("\033[0;36mExecute? [y/N] \033[0m").strip().lower()
-    if sys.stdin.isatty() and answer == "y":
-        subprocess.run(cmd, shell=True, executable=shutil.which(shell), check=False)
+    # do not run if not an interactive shell
+    if not sys.stdin.isatty():
+        print("Error: clipea is not running in an interactive shell")
+        return None
+
+    # confirms with user, default is "don't execute"
+    answer = input("\033[0;36mExecute [y/N] or [e]dit? \033[0m").strip().lower()
+    answer = "n" if answer == "" else answer
+    # abort if not yes or edit
+    if answer not in "ye":
+        return None
+
+    # enter editing mode if user wants
+    approved_cmd = edit_cmd(dirty_cmd) if answer == "e" else dirty_cmd
+    # add_to_history_cmd = get_history_cmd(approved_cmd)
+    subprocess.run(
+        approved_cmd,
+        shell=True,
+        executable=None if shell is None else get_current_shell(),
+        check=False,
+    )
+    return approved_cmd

--- a/clipea/cli.py
+++ b/clipea/cli.py
@@ -50,18 +50,6 @@ def get_current_shell() -> str:
     return current_shell
 
 
-def get_history_cmd(cmd: str) -> str:
-    """Adds a command to the shell's history
-    Args:
-        cmd (str): command to add
-    """
-    shell = get_current_shell()
-    if shell == "zsh":
-        return " ".join(["print", "-s", cmd])
-    elif shell == "bash":
-        return " ".join(["history", "-a", cmd])
-
-
 def find_shell(shell_name: str) -> str | None:
     """Finds the path to the shell passed
     Args:
@@ -108,13 +96,13 @@ def execute_after_approval(dirty_cmd: str, shell: Optional[str] = None) -> str |
     # confirms with user, default is "don't execute"
     answer = input("\033[0;36mExecute [y/N] or [e]dit? \033[0m").strip().lower()
     answer = "n" if answer == "" else answer
+
     # abort if not yes or edit
     if answer not in "ye":
         return None
 
     # enter editing mode if user wants
     approved_cmd = edit_cmd(dirty_cmd) if answer == "e" else dirty_cmd
-    # add_to_history_cmd = get_history_cmd(approved_cmd)
     subprocess.run(
         approved_cmd,
         shell=True,

--- a/clipea/cli.py
+++ b/clipea/cli.py
@@ -8,6 +8,7 @@ import sys
 import subprocess
 import shutil
 from typing import Optional
+from loguru import logger as log
 
 
 def get_input(max_len: int = 1 << 13) -> str:
@@ -46,7 +47,7 @@ def get_current_shell() -> str:
     # we fallback to the preferred user shell, indicated by the env var $SHELL:
     if current_shell not in available_shells:
         current_shell = os.path.basename(os.environ.get("SHELL", fallback_shell_path))
-    print(f"Current shell: {current_shell}")
+    log.debug(f"Current shell: {current_shell}")
     return current_shell
 
 
@@ -90,14 +91,14 @@ def execute_after_approval(dirty_cmd: str, shell: Optional[str] = None) -> str |
     """
     # do not run if not an interactive shell
     if not sys.stdin.isatty():
-        print("Error: clipea is not running in an interactive shell")
+        log.error("Error: clipea is not running in an interactive shell")
         return None
 
-    # confirms with user, default is "don't execute"
+    # confirms with user
     answer = input("\033[0;36mExecute [y/N] or [e]dit? \033[0m").strip().lower()
-    answer = "n" if answer == "" else answer
+    answer = "n" if not answer else answer # default is "don't execute"
 
-    # abort if not yes or edit
+    # abort if not [y]es or [e]dit
     if answer not in "ye":
         return None
 

--- a/clipea/clipea.sh
+++ b/clipea/clipea.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -i
+# Bash integration script for Clipea.
+
 # Shell should be interactive to better interact with
 #   history e.g. to get the user's $HISTTIMEFORMAT.
 set -e

--- a/clipea/clipea.sh
+++ b/clipea/clipea.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -i
+# Shell should be interactive to better interact with
+#   history e.g. to get the user's $HISTTIMEFORMAT.
+set -e
+
+# disable bash history until we're interested in it
+history -c
+set +o history
+
+CLIPEA_TMP_FILE=$(mktemp)
+trap 'rm -f ${CLIPEA_TMP_FILE}' EXIT
+
+# get this script's directory
+CLIPEA_SCRIPT_DIR=$(dirname "$0")
+CLIPEA_PATH=$(command -v clipea)
+CLIPEA_PYTHON=
+
+# run clipea from the current dir if possible
+if [[ -f ${CLIPEA_SCRIPT_DIR}/__main__.py ]]; then
+    CLIPEA_PATH=${CLIPEA_SCRIPT_DIR}
+    CLIPEA_PYTHON=$(command -v python3 || command -v python)
+fi
+
+# execute clipea with an environment variable
+echo "CLIPEA_TMP_FILE=${CLIPEA_TMP_FILE}"
+tail -f "${CLIPEA_TMP_FILE}" &
+CLIPEA_CMD_OUTPUT_FILE="${CLIPEA_TMP_FILE}" "${CLIPEA_PYTHON}" "${CLIPEA_PATH}" "$@"
+
+# read the command to be placed on the Bash command line
+echo "Saving $(wc -l <"${CLIPEA_TMP_FILE}") command(s) to history"
+
+# re-enable bash history and clear it to only add the relevant parts
+set -o history
+history -c
+while read -r line; do
+    history -s "${line}"
+done <"${CLIPEA_TMP_FILE}"

--- a/clipea/clipea.sh
+++ b/clipea/clipea.sh
@@ -1,16 +1,25 @@
 #!/bin/bash -i
 # Bash integration script for Clipea.
+# This file should remain with the Python implementation.
 
 # Shell should be interactive to better interact with
 #   history e.g. to get the user's $HISTTIMEFORMAT.
 set -e
+
+# enable debug if --debug is passed
+if [[ "$1" == "--debug" ]]; then
+    IS_DEBUG=1
+    shift
+else
+    IS_DEBUG=${IS_DEBUG:-0}
+fi
 
 # disable bash history until we're interested in it
 history -c
 set +o history
 
 CLIPEA_TMP_FILE=$(mktemp)
-trap 'rm -f ${CLIPEA_TMP_FILE}' EXIT
+# trap '/bin/rm -f ${CLIPEA_TMP_FILE}' EXIT
 
 # get this script's directory
 CLIPEA_SCRIPT_DIR=$(dirname "$0")
@@ -23,17 +32,27 @@ if [[ -f ${CLIPEA_SCRIPT_DIR}/__main__.py ]]; then
     CLIPEA_PYTHON=$(command -v python3 || command -v python)
 fi
 
+# check IS_DEBUG
+if [[ ${IS_DEBUG} -eq 1 ]]; then
+    echo "CLIPEA_TMP_FILE=${CLIPEA_TMP_FILE}"
+    tail -f "${CLIPEA_TMP_FILE}" &
+fi
+
 # execute clipea with an environment variable
-echo "CLIPEA_TMP_FILE=${CLIPEA_TMP_FILE}"
-tail -f "${CLIPEA_TMP_FILE}" &
 CLIPEA_CMD_OUTPUT_FILE="${CLIPEA_TMP_FILE}" "${CLIPEA_PYTHON}" "${CLIPEA_PATH}" "$@"
 
 # read the command to be placed on the Bash command line
-echo "Saving $(wc -l <"${CLIPEA_TMP_FILE}") command(s) to history"
+num_lines_to_save=$(grep -cv '^$' "${CLIPEA_TMP_FILE}")
+if [[ ${IS_DEBUG} -eq 1 ]]; then
+    echo "Saving ${num_lines_to_save} command(s) to history"
+    cat "${CLIPEA_TMP_FILE}"
+fi
 
 # re-enable bash history and clear it to only add the relevant parts
 set -o history
 history -c
 while read -r line; do
-    history -s "${line}"
+    if [[ -n "${line}" ]]; then
+        history -s "${line}"
+    fi
 done <"${CLIPEA_TMP_FILE}"


### PR DESCRIPTION
These changes improve integration with Bash and add inline editing. The video shows the edited command available with the up arrow after clipea terminates:

![demo](https://github.com/dave1010/clipea/assets/7535699/ad8ddb35-7049-41c0-b45c-942de22bdade)

Let me know what you think.

I tried not breaking zsh functionality and working around what was there, but it'd be good if someone else could try it on zsh next.

We'll probably reduce the output verbosity before merging, I left it in the demo to show what's happening.
