### PR TITLE
Added the ability to specify the OS via environment variables

### DIFF
--- a/clipea/__init__.py
+++ b/clipea/__init__.py
@@ -14,7 +14,7 @@ SYSTEM_PROMPT_FILE: str = utils.get_config_file_with_fallback(
 )
 ENV: dict[str, str] = {
     "shell": cli.get_shell(),
-    "platform": sys.platform,
+    "platform": os.getenv("OS", sys.platform),
     "editor": os.getenv("EDITOR", "nano"),
 }
 SYSTEM_PROMPT: str = utils.read_file(SYSTEM_PROMPT_FILE) + str(ENV)


### PR DESCRIPTION
Sometimes `sys.platform` identifies OS incorrectly *(e.g. i have MacBook with macOS 14 and it identifies as `posix`, not `darwin` or `osx` or `macos`, as i expected)*

so now platform is specified like this:
```python
os.getenv("OS", sys.platform)
``` 